### PR TITLE
Add innodb_io_capacity for higher throughput

### DIFF
--- a/etc/my.cnf.d/mariadb-config.general.d/innodb.cnf
+++ b/etc/my.cnf.d/mariadb-config.general.d/innodb.cnf
@@ -64,6 +64,17 @@ innodb_file_per_table = ON
 # https://mariadb.com/kb/en/innodb-system-variables/#innodb_flush_method
 innodb_flush_method = O_DIRECT
 
+# Limit on I/O activity for InnoDB background tasks, including merging data from the insert
+# buffer and flushing pages. Should be set to around the number of I/O operations per
+# second that system can handle, based on the type of drive/s being used.
+# You can also set it higher when the server starts to help with the extra workload
+# at that time, and then reduce for normal use.
+# Ideally, opt for a lower setting, as at higher value data is removed from the buffers
+# too quickly, reducing the effectiveness of caching. See also innodb_flush_sync.
+#
+# https://mariadb.com/kb/en/innodb-system-variables/#innodb_io_capacity
+innodb_io_capacity = 2000
+
 # Size in bytes of each InnoDB redo log file in the log group.
 # The combined size can be no more than 512GB.
 # Larger values mean less disk I/O due to less flushing checkpoint activity,
@@ -98,3 +109,4 @@ innodb_use_atomic_writes = ON
 #
 # https://mariadb.com/kb/en/innodb-system-variables/#innodb_write_io_threads
 innodb_write_io_threads = 32
+


### PR DESCRIPTION
Set innodb_io_capacity is set to 2000 which is good starting point, but it should be set to approximately the maximum number of IOPS the underlying storage can handle.

 * innodb_io_capacity = 2000