### PR TITLE
Removed duplicate variables

### DIFF
--- a/etc/mariadb-config/general.d/innodb.cnf
+++ b/etc/mariadb-config/general.d/innodb.cnf
@@ -95,7 +95,7 @@ innodb_log_file_size = 256M
 # disk I/O before committing.
 #
 # https://mariadb.com/kb/en/innodb-system-variables/#innodb_log_buffer_size
-innodb_log_buffer_size = 16M
+innodb_log_buffer_size = 32M
 
 # Number of I/O threads for InnoDB reads. You may on rare occasions need to reduce this
 # default on Linux systems running multiple MariaDB servers to avoid exceeding system limits.

--- a/etc/mariadb-config/general.d/perfomance.cnf
+++ b/etc/mariadb-config/general.d/perfomance.cnf
@@ -43,18 +43,6 @@ max_heap_table_size = 256M
 # https://mariadb.com/kb/en/performance-schema-system-variables/#performance_schema
 performance_schema = ON
 
-# Size in bytes for which results larger than this are not stored in the query cache. 
-#
-# https://mariadb.com/kb/en/server-system-variables/#query_cache_limit
-query_cache_limit = 128M
-
-# Size in bytes available to the query cache. About 40KB is needed for query cache structures,
-# so setting a size lower than this will result in a warning. 0, the default before MariaDB 10.1.7,
-# effectively disables the query cache. 
-#
-# https://mariadb.com/kb/en/server-system-variables/#query_cache_size
-query_cache_size = 10M
-
 # Maximum number of open tables cached in one table cache instance.
 # See Optimizing table_open_cache for suggestions on optimizing.
 # Increasing table_open_cache increases the number of file descriptors required. 

--- a/etc/mariadb-config/general.d/system.cnf
+++ b/etc/mariadb-config/general.d/system.cnf
@@ -7,13 +7,6 @@
 # https://mariadb.com/kb/en/server-system-variables/#skip_name_resolve
 skip-name-resolve = ON
 
-# Maximum number of open tables cached in one table cache instance.
-# See Optimizing table_open_cache for suggestions on optimizing.
-# Increasing table_open_cache increases the number of file descriptors required.
-#
-# https://mariadb.com/kb/en/server-system-variables/#table_open_cache
-table_open_cache = 4096
-
 # Size in bytes for which results larger than this are not stored in the query cache.
 #
 # https://mariadb.com/kb/en/server-system-variables/#query_cache_limit


### PR DESCRIPTION
Reorganized duplicate variables:
 * Remove from etc/mariadb-config/general.d/performance.cnf
   - query_cache_limit = 128M
   - query_cache_size = 10M

 * Remove from etc/mariadb-config/general.d/system.cnf
   - table_open_cache = 4096